### PR TITLE
discard the 1st DCT coefficient in mfcc

### DIFF
--- a/scikits/talkbox/features/mfcc.py
+++ b/scikits/talkbox/features/mfcc.py
@@ -107,7 +107,7 @@ def mfcc(input, nwin=256, nfft=512, fs=16000, nceps=13):
     # Filter the spectrum through the triangle filterbank
     mspec = np.log10(np.dot(spec, fbank.T))
     # Use the DCT to 'compress' the coefficients (spectrum -> cepstrum domain)
-    ceps = dct(mspec, type=2, norm='ortho', axis=-1)[:, :nceps]
+    ceps = dct(mspec, type=2, norm='ortho', axis=-1)[:, 1:nceps]
 
     return ceps, mspec, spec
 


### PR DESCRIPTION
The first DCT coefficient is affected by the sampling precision of the audio.
That is, for 2 audios with the same content but stored in different formats, like 32-bit floating-point and 32-bit PCM, the first coefficients of each frame are different while others are the same.
Therefore the first DCT coefficient should not be considered valid.
It's also instructed in [this tutorial](http://practicalcryptography.com/miscellaneous/machine-learning/guide-mel-frequency-cepstral-coefficients-mfccs/) to "Keep DCT coefficients 2-13, discard the rest".